### PR TITLE
fix oAuth2

### DIFF
--- a/config.ts.example
+++ b/config.ts.example
@@ -7,3 +7,8 @@ export const CLIENT_OPTIONS: DashboardClientOptions = {
 	clientSecret: '',
 	dashboardHooks: { port: 8282, apiPrefix: '' }
 };
+
+export const OAUTH2_OPTIONS: OAuth2Options = {
+	redirectUris: 'http://localhost:8282/oauth/callback',
+	scopes: ['identify', 'guilds']
+};

--- a/src/lib/third_party/klasa-dashboard-hooks/lib/structures/DashboardGuild.ts
+++ b/src/lib/third_party/klasa-dashboard-hooks/lib/structures/DashboardGuild.ts
@@ -1,7 +1,5 @@
 // Copyright (c) 2017-2018 dirigeants. All rights reserved. MIT license.
-import { Collection } from '../../../collection/lib/Collection';
 import { DashboardClient } from '../DashboardClient';
-import { DashboardUser } from './DashboardUser';
 
 /**
  * The dashboard guild data
@@ -10,6 +8,8 @@ export type DashboardGuildData = {
 	id: string;
 	name: string;
 	icon: string | null;
+	owner: boolean;
+	permissions: number;
 };
 
 export class DashboardGuild {
@@ -35,15 +35,22 @@ export class DashboardGuild {
 	public icon: string;
 
 	/**
-	 * The OAuth Users this DashboardGuild is for
+	 * Whether or not the user is the owner
 	 */
-	public users: Collection<string, DashboardUser> = new Collection();
+	public owner: boolean;
+
+	/**
+	 * The permissions of this user in this guild
+	 */
+	public permissions: number;
 
 	public constructor(client: DashboardClient, data: DashboardGuildData) {
 		this.client = client;
+		this.owner = data.owner;
+		this.permissions = data.permissions;
+		this.icon = data.icon;
 		this.id = data.id;
 		this.name = data.name;
-		this.icon = data.icon;
 	}
 
 	/**
@@ -60,7 +67,9 @@ export class DashboardGuild {
 		return {
 			icon: this.icon,
 			id: this.id,
-			name: this.name
+			name: this.name,
+			owner: this.owner,
+			permissions: this.permissions
 		};
 	}
 

--- a/src/lib/third_party/klasa-dashboard-hooks/lib/structures/DashboardUser.ts
+++ b/src/lib/third_party/klasa-dashboard-hooks/lib/structures/DashboardUser.ts
@@ -58,6 +58,17 @@ export class DashboardUser {
 	 */
 	public username: string;
 
+	public constructor(client: DashboardClient, data: DashboardUserData & { mfaEnabled: never; mfa_enabled: boolean }) {
+		this.client = client;
+		this.username = data.username;
+		this.locale = data.locale;
+		this.mfaEnabled = data.mfa_enabled;
+		this.avatar = data.avatar;
+		this.discriminator = Number(data.discriminator);
+		this.id = data.id;
+		for (const guild of data.guilds) this.guilds.set(guild.id, new DashboardGuild(this.client, guild));
+	}
+
 	public avatarURL(): string {
 		return this.avatar
 			? `https://cdn.discordapp.com/avatars/${this.id}/${this.avatar}.png`

--- a/src/routes/oauth/oauthcallback.ts
+++ b/src/routes/oauth/oauthcallback.ts
@@ -4,7 +4,7 @@ import { URL } from 'url';
 import { APIClient } from '../../lib/APIClient';
 import { DashboardClient, encrypt, KlasaIncomingMessage, RESPONSES, Route, RouteStore } from '../../lib/third_party/klasa-dashboard-hooks';
 
-import {OAUTH2_OPTIONS} from "./../../../config";
+import { OAUTH2_OPTIONS } from './../../../config';
 
 export default class extends Route {
 
@@ -19,30 +19,27 @@ export default class extends Route {
 	}
 
 	public async get(request: KlasaIncomingMessage, response: ServerResponse): Promise<void> {
-		if (!request.query.code || typeof request.query.code !== "string") {
+		if (!request.query.code || typeof request.query.code !== 'string') {
 			this.noCode(response);
 			return;
 		}
-		
+
 		const url = new URL('https://discordapp.com/api/oauth2/token');
-		
+
 		url.searchParams.append('client_id', this.client.options.clientID);
 		url.searchParams.append('client_secret', this.client.options.clientSecret);
 		url.searchParams.append('grant_type', 'authorization_code');
 		url.searchParams.append('redirect_uri', OAUTH2_OPTIONS.redirectUris);
 		url.searchParams.append('code', request.query.code);
-		url.searchParams.append('scope', OAUTH2_OPTIONS.scopes.join(" "));
-		
-		const res = await fetch(url as any, {
-			method: 'POST'
-		});
+		url.searchParams.append('scope', OAUTH2_OPTIONS.scopes.join(' '));
+
+		const res = await fetch(url as any, { method: 'POST' });
 		if (!res.ok) {
 			response.end(RESPONSES.FETCHING_TOKEN);
 			return;
 		}
 
 		const oauthUser = this.oauthUser;
-
 		if (!oauthUser) {
 			this.notReady(response);
 			return;

--- a/src/routes/oauth/oauthinit.ts
+++ b/src/routes/oauth/oauthinit.ts
@@ -3,26 +3,26 @@ import { URL } from 'url';
 import { APIClient } from '../../lib/APIClient';
 import { DashboardClient, KlasaIncomingMessage, Route, RouteStore } from '../../lib/third_party/klasa-dashboard-hooks';
 
-import {OAUTH2_OPTIONS} from "./../../../config";
+import { OAUTH2_OPTIONS } from './../../../config';
 
 export default class extends Route {
 
 	public client: APIClient;
 
 	public constructor(client: DashboardClient, store: RouteStore, file: string[], directory: string) {
-		super(client, store, file, directory, { route: '/oauth/init', authenticated: false });
+		super(client, store, file, directory, { route: '/oauth/init' });
 	}
 
 	public get(_request: KlasaIncomingMessage, response: ServerResponse): void {
 
 		const url = new URL('https://discordapp.com/api/oauth2/authorize');
-		
+
 		// @todo: implement state https://discordapp.com/developers/docs/topics/oauth2#state-and-security
 		url.searchParams.append('client_id', this.client.options.clientID);
 		url.searchParams.append('client_secret', this.client.options.clientSecret);
 		url.searchParams.append('response_type', 'code');
 		url.searchParams.append('redirect_uri', OAUTH2_OPTIONS.redirectUris);
-		url.searchParams.append('scope', OAUTH2_OPTIONS.scopes.join(" "));
+		url.searchParams.append('scope', OAUTH2_OPTIONS.scopes.join(' '));
 
 		response.writeHead(302, {
 			'Location': url.toString()

--- a/src/routes/oauth/oauthinit.ts
+++ b/src/routes/oauth/oauthinit.ts
@@ -15,19 +15,19 @@ export default class extends Route {
 
 	public get(_request: KlasaIncomingMessage, response: ServerResponse): void {
 
-    const url = new URL('https://discordapp.com/api/oauth2/authorize');
-    
-    // @todo: implement state https://discordapp.com/developers/docs/topics/oauth2#state-and-security
+		const url = new URL('https://discordapp.com/api/oauth2/authorize');
+		
+		// @todo: implement state https://discordapp.com/developers/docs/topics/oauth2#state-and-security
 		url.searchParams.append('client_id', this.client.options.clientID);
 		url.searchParams.append('client_secret', this.client.options.clientSecret);
 		url.searchParams.append('response_type', 'code');
 		url.searchParams.append('redirect_uri', OAUTH2_OPTIONS.redirectUris);
-    url.searchParams.append('scope', OAUTH2_OPTIONS.scopes.join(" "));
+		url.searchParams.append('scope', OAUTH2_OPTIONS.scopes.join(" "));
 
-    response.writeHead(302, {
-      'Location': url.toString()
-    });
-    response.end();
+		response.writeHead(302, {
+			'Location': url.toString()
+		});
+		response.end();
 	}
 
 }

--- a/src/routes/oauth/oauthinit.ts
+++ b/src/routes/oauth/oauthinit.ts
@@ -1,0 +1,33 @@
+import { ServerResponse } from 'http';
+import { URL } from 'url';
+import { APIClient } from '../../lib/APIClient';
+import { DashboardClient, KlasaIncomingMessage, Route, RouteStore } from '../../lib/third_party/klasa-dashboard-hooks';
+
+import {OAUTH2_OPTIONS} from "./../../../config";
+
+export default class extends Route {
+
+	public client: APIClient;
+
+	public constructor(client: DashboardClient, store: RouteStore, file: string[], directory: string) {
+		super(client, store, file, directory, { route: '/oauth/init', authenticated: false });
+	}
+
+	public get(_request: KlasaIncomingMessage, response: ServerResponse): void {
+
+    const url = new URL('https://discordapp.com/api/oauth2/authorize');
+    
+    // @todo: implement state https://discordapp.com/developers/docs/topics/oauth2#state-and-security
+		url.searchParams.append('client_id', this.client.options.clientID);
+		url.searchParams.append('client_secret', this.client.options.clientSecret);
+		url.searchParams.append('response_type', 'code');
+		url.searchParams.append('redirect_uri', OAUTH2_OPTIONS.redirectUris);
+    url.searchParams.append('scope', OAUTH2_OPTIONS.scopes.join(" "));
+
+    response.writeHead(302, {
+      'Location': url.toString()
+    });
+    response.end();
+	}
+
+}

--- a/src/types/Oauth.ts
+++ b/src/types/Oauth.ts
@@ -1,3 +1,6 @@
+/**
+ * The OAuth2 options
+ */
 export type OAuth2Options = {
 	scopes: ReadonlyArray<string>;
 	redirectUris: string;

--- a/src/types/Oauth.ts
+++ b/src/types/Oauth.ts
@@ -1,0 +1,4 @@
+export type OAuth2Options = {
+	scopes: ReadonlyArray<string>;
+	redirectUris: string;
+};


### PR DESCRIPTION
The current implementation for oauth2 is wrong. 

This fixes it, but is still breaking since datastore is not saving the user guilds properly. 

I also added the oauth2 config on config.ts since didn't see a better place.

@kyranet could you please move it?
```typescript
type OAuth2Options = {
  redirectUris: string,
  scopes: ReadonlyArray<string>,
}

export const OAUTH2_OPTIONS: OAuth2Options = {
  redirectUris: "http://localhost:8282/oauth/callback", 
  scopes: ["identify", "email", "guilds"]
}
```